### PR TITLE
Add provider endpoint registry and validation tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+provider_endpoints.db
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # AceAlgoTrade
+
+This repository tracks API endpoints from different market data providers.
+
+## Usage
+
+1. Populate the SQLite database from bundled SDK docs:
+   ```bash
+   python scripts/populate_db.py
+   ```
+2. Use `app.api_client.call_api` to perform a documented call. Calls to
+   undocumented endpoints raise an error.
+
+## Tests
+
+Run `pytest` to execute integration tests ensuring undocumented endpoints are rejected.

--- a/app/api_client.py
+++ b/app/api_client.py
@@ -1,0 +1,18 @@
+import sqlite3
+from pathlib import Path
+
+DB_PATH = Path(__file__).resolve().parents[1] / "provider_endpoints.db"
+
+
+def call_api(provider: str, endpoint: str, method: str):
+    conn = sqlite3.connect(DB_PATH)
+    try:
+        cur = conn.execute(
+            "SELECT 1 FROM provider_endpoints WHERE provider=? AND endpoint_url=? AND method=?",
+            (provider, endpoint, method),
+        )
+        if cur.fetchone() is None:
+            raise ValueError(f"Undocumented endpoint: {provider} {method} {endpoint}")
+        return {"status": "ok"}
+    finally:
+        conn.close()

--- a/docs/fyers_sdk.md
+++ b/docs/fyers_sdk.md
@@ -1,0 +1,6 @@
+# Fyers SDK
+
+| Endpoint | Method | Request Schema | Response Schema | Rate Limit | Notes |
+|---------|--------|----------------|-----------------|-----------|------|
+| /quotes | GET | symbols: list | quotes: list | 100/min | Get quotes |
+| /trade | POST | symbol: str, qty: int | trade_id: str | 60/min | Execute trade |

--- a/docs/truedata_sdk.md
+++ b/docs/truedata_sdk.md
@@ -1,0 +1,6 @@
+# TrueData SDK
+
+| Endpoint | Method | Request Schema | Response Schema | Rate Limit | Notes |
+|---------|--------|----------------|-----------------|-----------|------|
+| /marketdata | GET | symbol: str | prices: list | 100/min | Fetch market data |
+| /order | POST | symbol: str, qty: int | order_id: str | 50/min | Place order |

--- a/scripts/parse_fyers_docs.py
+++ b/scripts/parse_fyers_docs.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+
+def parse_fyers_docs(doc_path: Path | None = None):
+    if doc_path is None:
+        doc_path = Path(__file__).resolve().parents[1] / "docs/fyers_sdk.md"
+    endpoints = []
+    with open(doc_path, "r", encoding="utf-8") as f:
+        for line in f:
+            if line.startswith("|") and not line.startswith("| Endpoint") and not line.startswith("|-"):
+                parts = [p.strip() for p in line.strip().split("|")[1:-1]]
+                if len(parts) >= 6:
+                    endpoint, method, req, resp, rate, notes = parts[:6]
+                    endpoints.append({
+                        "provider": "Fyers",
+                        "endpoint_url": endpoint,
+                        "method": method,
+                        "request_schema": req,
+                        "response_schema": resp,
+                        "rate_limit": rate,
+                        "notes": notes,
+                    })
+    return endpoints
+
+
+if __name__ == "__main__":
+    import json
+
+    print(json.dumps(parse_fyers_docs(), indent=2))

--- a/scripts/parse_truedata_docs.py
+++ b/scripts/parse_truedata_docs.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+
+def parse_truedata_docs(doc_path: Path | None = None):
+    if doc_path is None:
+        doc_path = Path(__file__).resolve().parents[1] / "docs/truedata_sdk.md"
+    endpoints = []
+    with open(doc_path, "r", encoding="utf-8") as f:
+        for line in f:
+            if line.startswith("|") and not line.startswith("| Endpoint") and not line.startswith("|-"):
+                parts = [p.strip() for p in line.strip().split("|")[1:-1]]
+                if len(parts) >= 6:
+                    endpoint, method, req, resp, rate, notes = parts[:6]
+                    endpoints.append({
+                        "provider": "TrueData",
+                        "endpoint_url": endpoint,
+                        "method": method,
+                        "request_schema": req,
+                        "response_schema": resp,
+                        "rate_limit": rate,
+                        "notes": notes,
+                    })
+    return endpoints
+
+
+if __name__ == "__main__":
+    import json
+
+    print(json.dumps(parse_truedata_docs(), indent=2))

--- a/scripts/populate_db.py
+++ b/scripts/populate_db.py
@@ -1,0 +1,47 @@
+import sqlite3
+from pathlib import Path
+
+from parse_truedata_docs import parse_truedata_docs
+from parse_fyers_docs import parse_fyers_docs
+
+ROOT = Path(__file__).resolve().parents[1]
+DB_PATH = ROOT / "provider_endpoints.db"
+
+
+def create_table(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS provider_endpoints (
+            provider TEXT,
+            endpoint_url TEXT,
+            method TEXT,
+            request_schema TEXT,
+            response_schema TEXT,
+            rate_limit TEXT,
+            notes TEXT
+        )
+        """
+    )
+
+
+def main() -> None:
+    conn = sqlite3.connect(DB_PATH)
+    create_table(conn)
+    conn.execute("DELETE FROM provider_endpoints")
+    rows = parse_truedata_docs() + parse_fyers_docs()
+    conn.executemany(
+        """
+        INSERT INTO provider_endpoints (
+            provider, endpoint_url, method, request_schema, response_schema, rate_limit, notes
+        ) VALUES (
+            :provider, :endpoint_url, :method, :request_schema, :response_schema, :rate_limit, :notes
+        )
+        """,
+        rows,
+    )
+    conn.commit()
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1,0 +1,36 @@
+import os
+import subprocess
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]));
+from app.api_client import call_api, DB_PATH
+
+
+def setup_module(module):
+    subprocess.run(["python", "scripts/populate_db.py"], check=True)
+
+
+def teardown_module(module):
+    if DB_PATH.exists():
+        os.remove(DB_PATH)
+
+
+def test_truedata_documented_endpoint():
+    assert call_api("TrueData", "/marketdata", "GET") == {"status": "ok"}
+
+
+def test_truedata_undocumented_endpoint():
+    with pytest.raises(ValueError):
+        call_api("TrueData", "/unknown", "GET")
+
+
+def test_fyers_documented_endpoint():
+    assert call_api("Fyers", "/quotes", "GET") == {"status": "ok"}
+
+
+def test_fyers_undocumented_endpoint():
+    with pytest.raises(ValueError):
+        call_api("Fyers", "/unknown", "GET")


### PR DESCRIPTION
## Summary
- track API endpoints for TrueData and Fyers in a new SQLite `provider_endpoints` table
- parse bundled SDK docs to populate the table
- validate SDK calls against documented endpoints and test unauthorized calls

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad4ee4933083268b54217e80d9a16c