### PR TITLE
Add auth, HTTP retry, WebSocket, and rate limit utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # AceAlgoTrade
+
+Utilities for building trading algorithms with robust API access.
+
+## Modules
+
+- `ace_algo_trade/auth.py`: token acquisition and refresh via `TokenManager`.
+- `ace_algo_trade/rest_client.py`: retry/backoff HTTP requests with optional rate limiting.
+- `ace_algo_trade/websocket_client.py`: WebSocket client with reconnection and heartbeat.
+- `ace_algo_trade/rate_limiter.py`: persists rate limit metadata and enforces throttling.

--- a/ace_algo_trade/__init__.py
+++ b/ace_algo_trade/__init__.py
@@ -1,0 +1,13 @@
+"""Core modules for AceAlgoTrade."""
+
+from .auth import TokenManager
+from .rate_limiter import RateLimiter
+from .rest_client import request
+from .websocket_client import WebSocketClient
+
+__all__ = [
+    "TokenManager",
+    "RateLimiter",
+    "request",
+    "WebSocketClient",
+]

--- a/ace_algo_trade/auth.py
+++ b/ace_algo_trade/auth.py
@@ -1,0 +1,68 @@
+import time
+from typing import Optional
+
+import requests
+
+
+class TokenManager:
+    """Handle token acquisition and refresh logic for API providers."""
+
+    def __init__(
+        self,
+        auth_url: str,
+        refresh_url: str,
+        client_id: str,
+        client_secret: str,
+    ) -> None:
+        self.auth_url = auth_url
+        self.refresh_url = refresh_url
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.access_token: Optional[str] = None
+        self.refresh_token: Optional[str] = None
+        self.expiry: float = 0.0
+
+    def _request_token(self, url: str, data: dict) -> dict:
+        resp = requests.post(url, data=data, timeout=10)
+        resp.raise_for_status()
+        payload = resp.json()
+        self.access_token = payload.get("access_token")
+        self.refresh_token = payload.get("refresh_token", self.refresh_token)
+        expires_in = payload.get("expires_in", 0)
+        self.expiry = time.time() + expires_in
+        return payload
+
+    def authenticate(self, scope: Optional[str] = None) -> dict:
+        """Acquire a new access token."""
+        data = {
+            "grant_type": "client_credentials",
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+        }
+        if scope:
+            data["scope"] = scope
+        return self._request_token(self.auth_url, data)
+
+    def refresh(self) -> dict:
+        """Refresh an existing access token."""
+        if not self.refresh_token:
+            raise ValueError("No refresh token available")
+        data = {
+            "grant_type": "refresh_token",
+            "refresh_token": self.refresh_token,
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+        }
+        return self._request_token(self.refresh_url, data)
+
+    def get_token(self) -> str:
+        """Return a valid access token, refreshing if necessary."""
+        if self.access_token and time.time() < self.expiry - 60:
+            return self.access_token
+        if self.refresh_token:
+            self.refresh()
+        else:
+            self.authenticate()
+        if not self.access_token:
+            raise RuntimeError("Failed to obtain access token")
+        return self.access_token

--- a/ace_algo_trade/rate_limiter.py
+++ b/ace_algo_trade/rate_limiter.py
@@ -1,0 +1,67 @@
+import sqlite3
+import time
+from threading import Lock
+from typing import Optional
+
+
+class RateLimiter:
+    """Persist rate limit metadata and enforce client-side throttling."""
+
+    def __init__(self, db_path: str = "rate_limits.db") -> None:
+        self.db_path = db_path
+        self._lock = Lock()
+        self._init_db()
+
+    def _init_db(self) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS limits (
+                    provider TEXT PRIMARY KEY,
+                    request_limit INTEGER NOT NULL,
+                    window INTEGER NOT NULL,
+                    count INTEGER NOT NULL,
+                    last_reset REAL NOT NULL
+                )
+                """
+            )
+            conn.commit()
+
+    def configure(self, provider: str, limit: int, window: int) -> None:
+        """Set the rate limit information for a provider."""
+        now = time.time()
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO limits(provider, request_limit, window, count, last_reset)
+                VALUES(?, ?, ?, ?, ?)
+                """,
+                (provider, limit, window, 0, now),
+            )
+            conn.commit()
+
+    def throttle(self, provider: str) -> None:
+        """Block if the provider's rate limit would be exceeded."""
+        with self._lock, sqlite3.connect(self.db_path) as conn:
+            row = conn.execute(
+                "SELECT request_limit, window, count, last_reset FROM limits WHERE provider=?",
+                (provider,),
+            ).fetchone()
+            if not row:
+                return
+            limit, window, count, last_reset = row
+            now = time.time()
+            if now - last_reset >= window:
+                count = 0
+                last_reset = now
+            if count >= limit:
+                sleep_time = window - (now - last_reset)
+                if sleep_time > 0:
+                    time.sleep(sleep_time)
+                count = 0
+                last_reset = time.time()
+            conn.execute(
+                "UPDATE limits SET count=?, last_reset=? WHERE provider=?",
+                (count + 1, last_reset, provider),
+            )
+            conn.commit()

--- a/ace_algo_trade/rest_client.py
+++ b/ace_algo_trade/rest_client.py
@@ -1,0 +1,30 @@
+from typing import Optional
+
+import requests
+from requests import Response
+from requests.exceptions import RequestException
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
+
+from .rate_limiter import RateLimiter
+
+
+@retry(
+    reraise=True,
+    stop=stop_after_attempt(5),
+    wait=wait_exponential(multiplier=1, min=1, max=10),
+    retry=retry_if_exception_type(RequestException),
+)
+def request(
+    method: str,
+    url: str,
+    *,
+    provider: Optional[str] = None,
+    rate_limiter: Optional[RateLimiter] = None,
+    **kwargs,
+) -> Response:
+    """Perform an HTTP request with retry/backoff and optional throttling."""
+    if provider and rate_limiter:
+        rate_limiter.throttle(provider)
+    resp = requests.request(method, url, timeout=10, **kwargs)
+    resp.raise_for_status()
+    return resp

--- a/ace_algo_trade/websocket_client.py
+++ b/ace_algo_trade/websocket_client.py
@@ -1,0 +1,79 @@
+import threading
+import time
+from typing import Callable, Optional
+
+import websocket
+
+
+class WebSocketClient:
+    """Maintain a resilient WebSocket connection with heartbeat and reconnection."""
+
+    def __init__(
+        self,
+        url: str,
+        on_message: Callable[[str], None],
+        *,
+        heartbeat_interval: int = 30,
+        reconnect_delay: int = 5,
+    ) -> None:
+        self.url = url
+        self.on_message = on_message
+        self.heartbeat_interval = heartbeat_interval
+        self.reconnect_delay = reconnect_delay
+        self.ws: Optional[websocket.WebSocket] = None
+        self.stop_event = threading.Event()
+        self._hb_thread: Optional[threading.Thread] = None
+        self._listen_thread: Optional[threading.Thread] = None
+
+    def connect(self) -> None:
+        """Establish the WebSocket connection."""
+        self._connect()
+
+    def _connect(self) -> None:
+        while not self.stop_event.is_set():
+            try:
+                self.ws = websocket.create_connection(self.url)
+                self._start_threads()
+                break
+            except Exception:
+                time.sleep(self.reconnect_delay)
+
+    def _start_threads(self) -> None:
+        self._listen_thread = threading.Thread(target=self._listener, daemon=True)
+        self._listen_thread.start()
+        self._hb_thread = threading.Thread(target=self._heartbeat, daemon=True)
+        self._hb_thread.start()
+
+    def _listener(self) -> None:
+        while not self.stop_event.is_set():
+            try:
+                msg = self.ws.recv()
+                if msg is None:
+                    raise websocket.WebSocketConnectionClosedException()
+                self.on_message(msg)
+            except Exception:
+                self._reconnect()
+                break
+
+    def _heartbeat(self) -> None:
+        while not self.stop_event.is_set():
+            try:
+                self.ws.ping()
+            except Exception:
+                self._reconnect()
+                break
+            time.sleep(self.heartbeat_interval)
+
+    def _reconnect(self) -> None:
+        if self.stop_event.is_set():
+            return
+        time.sleep(self.reconnect_delay)
+        self._connect()
+
+    def close(self) -> None:
+        self.stop_event.set()
+        if self.ws:
+            try:
+                self.ws.close()
+            finally:
+                self.ws = None


### PR DESCRIPTION
## Summary
- add TokenManager for OAuth token acquisition and refresh
- provide HTTP request helper with tenacity-based retry and optional throttling
- implement resilient WebSocket client with heartbeat and reconnection
- track per-provider limits in SQLite and throttle requests

## Testing
- `python -m py_compile ace_algo_trade/*.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad5103259083269545e57d7c22fb5b