### PR TITLE
Add SQL schema, seed data, and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
 # AceAlgoTrade
+
+## Database Migrations
+
+The `db/migrations/001_create_tables.sql` file defines the schema for all core tables:
+`users`, `brokers`, `providers`, `accounts`, `symbols`, `symbol_mappings`, `orders`, `trades`,
+`positions`, and `provider_endpoints`.
+
+Apply the migration with SQLite:
+
+```bash
+sqlite3 mydb.db < db/migrations/001_create_tables.sql
+```
+
+## Seed Data
+
+Populate the database with example providers, broker, test user, and sample symbols:
+
+```bash
+sqlite3 mydb.db < db/seed.sql
+```
+
+## Testing
+
+Run schema validation tests to ensure relationships and constraints remain valid:
+
+```bash
+pytest
+```
+

--- a/db/migrations/001_create_tables.sql
+++ b/db/migrations/001_create_tables.sql
@@ -1,0 +1,92 @@
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE users (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  username TEXT NOT NULL UNIQUE,
+  email TEXT NOT NULL UNIQUE,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE brokers (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL UNIQUE
+);
+
+CREATE TABLE providers (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL UNIQUE
+);
+
+CREATE TABLE accounts (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id INTEGER NOT NULL,
+  broker_id INTEGER NOT NULL,
+  provider_id INTEGER,
+  account_number TEXT NOT NULL UNIQUE,
+  FOREIGN KEY(user_id) REFERENCES users(id),
+  FOREIGN KEY(broker_id) REFERENCES brokers(id),
+  FOREIGN KEY(provider_id) REFERENCES providers(id)
+);
+
+CREATE TABLE symbols (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  ticker TEXT NOT NULL UNIQUE,
+  name TEXT
+);
+
+CREATE TABLE symbol_mappings (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  provider_id INTEGER NOT NULL,
+  symbol_id INTEGER NOT NULL,
+  provider_symbol TEXT NOT NULL,
+  FOREIGN KEY(provider_id) REFERENCES providers(id),
+  FOREIGN KEY(symbol_id) REFERENCES symbols(id),
+  UNIQUE(provider_id, provider_symbol),
+  UNIQUE(provider_id, symbol_id)
+);
+
+CREATE TABLE orders (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  account_id INTEGER NOT NULL,
+  symbol_id INTEGER NOT NULL,
+  side TEXT NOT NULL,
+  quantity REAL NOT NULL,
+  price REAL,
+  status TEXT NOT NULL,
+  placed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY(account_id) REFERENCES accounts(id),
+  FOREIGN KEY(symbol_id) REFERENCES symbols(id)
+);
+
+CREATE TABLE trades (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  order_id INTEGER NOT NULL,
+  account_id INTEGER NOT NULL,
+  symbol_id INTEGER NOT NULL,
+  quantity REAL NOT NULL,
+  price REAL NOT NULL,
+  executed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY(order_id) REFERENCES orders(id),
+  FOREIGN KEY(account_id) REFERENCES accounts(id),
+  FOREIGN KEY(symbol_id) REFERENCES symbols(id)
+);
+
+CREATE TABLE positions (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  account_id INTEGER NOT NULL,
+  symbol_id INTEGER NOT NULL,
+  quantity REAL NOT NULL,
+  avg_price REAL NOT NULL,
+  FOREIGN KEY(account_id) REFERENCES accounts(id),
+  FOREIGN KEY(symbol_id) REFERENCES symbols(id),
+  UNIQUE(account_id, symbol_id)
+);
+
+CREATE TABLE provider_endpoints (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  provider_id INTEGER NOT NULL,
+  name TEXT NOT NULL,
+  url TEXT NOT NULL,
+  FOREIGN KEY(provider_id) REFERENCES providers(id),
+  UNIQUE(provider_id, name)
+);

--- a/db/seed.sql
+++ b/db/seed.sql
@@ -1,0 +1,7 @@
+INSERT INTO providers (name) VALUES ('DemoProvider');
+INSERT INTO brokers (name) VALUES ('DemoBroker');
+INSERT INTO users (username, email) VALUES ('testuser', 'test@example.com');
+INSERT INTO symbols (ticker, name) VALUES ('AAPL', 'Apple Inc.'), ('GOOG', 'Alphabet Inc.');
+INSERT INTO accounts (user_id, broker_id, provider_id, account_number) VALUES (1, 1, 1, 'ACC123');
+INSERT INTO provider_endpoints (provider_id, name, url) VALUES (1, 'trade', 'https://api.demoprovider.com/trade');
+INSERT INTO symbol_mappings (provider_id, symbol_id, provider_symbol) VALUES (1, 1, 'AAPL'), (1, 2, 'GOOG');

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,80 @@
+from pathlib import Path
+import sqlite3
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+MIGRATIONS = ROOT / 'db' / 'migrations' / '001_create_tables.sql'
+SEED = ROOT / 'db' / 'seed.sql'
+
+
+def run_script(cursor, path):
+    with open(path, 'r', encoding='utf-8') as f:
+        cursor.executescript(f.read())
+
+
+def test_tables_created():
+    conn = sqlite3.connect(':memory:')
+    conn.execute('PRAGMA foreign_keys = ON')
+    cur = conn.cursor()
+    run_script(cur, MIGRATIONS)
+    tables = {row[0] for row in cur.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    expected = {
+        'users', 'brokers', 'providers', 'accounts', 'symbols',
+        'symbol_mappings', 'orders', 'trades', 'positions', 'provider_endpoints'
+    }
+    assert expected.issubset(tables)
+    conn.close()
+
+
+def test_relationships_and_constraints():
+    conn = sqlite3.connect(':memory:')
+    conn.execute('PRAGMA foreign_keys = ON')
+    cur = conn.cursor()
+    run_script(cur, MIGRATIONS)
+
+    cur.execute("INSERT INTO providers (name) VALUES ('P')")
+    cur.execute("INSERT INTO brokers (name) VALUES ('B')")
+    cur.execute("INSERT INTO users (username, email) VALUES ('u', 'u@example.com')")
+    cur.execute("INSERT INTO symbols (ticker, name) VALUES ('SYM', 'Sym')")
+    cur.execute("INSERT INTO accounts (user_id, broker_id, provider_id, account_number) VALUES (1,1,1,'ACC')")
+
+    with pytest.raises(sqlite3.IntegrityError):
+        cur.execute("INSERT INTO accounts (user_id, broker_id, provider_id, account_number) VALUES (2,1,1,'ACC2')")
+
+    cur.execute("INSERT INTO symbol_mappings (provider_id, symbol_id, provider_symbol) VALUES (1,1,'SYM')")
+    with pytest.raises(sqlite3.IntegrityError):
+        cur.execute("INSERT INTO symbol_mappings (provider_id, symbol_id, provider_symbol) VALUES (1,1,'SYM')")
+
+    cur.execute("INSERT INTO positions (account_id, symbol_id, quantity, avg_price) VALUES (1,1,10,150)")
+    with pytest.raises(sqlite3.IntegrityError):
+        cur.execute("INSERT INTO positions (account_id, symbol_id, quantity, avg_price) VALUES (1,1,20,155)")
+
+    cur.execute("INSERT INTO provider_endpoints (provider_id, name, url) VALUES (1, 'trade', 'u')")
+    with pytest.raises(sqlite3.IntegrityError):
+        cur.execute("INSERT INTO provider_endpoints (provider_id, name, url) VALUES (1, 'trade', 'u2')")
+
+    cur.execute("INSERT INTO orders (account_id, symbol_id, side, quantity, price, status) VALUES (1,1,'BUY',10,100,'open')")
+    with pytest.raises(sqlite3.IntegrityError):
+        cur.execute("INSERT INTO orders (account_id, symbol_id, side, quantity, price, status) VALUES (2,1,'BUY',10,100,'open')")
+
+    cur.execute("INSERT INTO trades (order_id, account_id, symbol_id, quantity, price) VALUES (1,1,1,10,100)")
+    with pytest.raises(sqlite3.IntegrityError):
+        cur.execute("INSERT INTO trades (order_id, account_id, symbol_id, quantity, price) VALUES (2,1,1,10,100)")
+
+    conn.close()
+
+
+def test_seed_script():
+    conn = sqlite3.connect(':memory:')
+    conn.execute('PRAGMA foreign_keys = ON')
+    cur = conn.cursor()
+    run_script(cur, MIGRATIONS)
+    run_script(cur, SEED)
+    user = cur.execute('SELECT username FROM users').fetchone()[0]
+    provider = cur.execute('SELECT name FROM providers').fetchone()[0]
+    symbol_count = cur.execute('SELECT COUNT(*) FROM symbols').fetchone()[0]
+    assert user == 'testuser'
+    assert provider == 'DemoProvider'
+    assert symbol_count == 2
+    conn.close()
+


### PR DESCRIPTION
## Summary
- add SQL migration for core trading tables
- seed example provider, broker, user, and symbols
- validate schema integrity with pytest

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad4f8239bc83268c3be75a09a8a5fd